### PR TITLE
Added ability to use in `http.FS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,14 @@ This also means that it should be safe for concurrent use.
 
 Care should be taken when creating a zip file. For instance, the `sqlfiles.zip` file in the `testdata` folder was 
 created on a Mac by selecting the folder in the finder, and then selecting the compress option on the context menu. 
-This creates the zip file with the folder included in the file structure. Therefore all of your paths must
+This creates the zip file with the folder included in the file structure. Therefore, all of your paths must
 include this folder. See below and the tests for examples.
 
-## Example
+**UPDATE:** It is now possible to use the manager directly as a `fs.FS` (filesystem) and hence can be used as a
+file server within an http server.
+
+## Examples
+Normal usage:
 ```go
 mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
 fileKey := filepath.Join("sqlfiles","default", "selectDual.sql")
@@ -32,4 +36,12 @@ fmt.Printf("%s", res)
 //   *
 // from
 //   DUAL
+```
+
+HTTP usage:
+
+```go
+mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
+mux := http.NewServeMux()
+mux.Handle("/", http.FileServer(http.FS(mgr)))
 ```

--- a/doc.go
+++ b/doc.go
@@ -1,10 +1,10 @@
-// Package zipack provides a simple object to read files directly from a zip file and cache the results.
+// Package zipack provides a simple object to read files directly from a zip zipfile and cache the results.
 //
 // The struct utilises the sync.Map instead of the built-in map as the cache will only increase and
 // will not be deleting keys. This means that it should be safe for concurrent use.
 //
-// Care should be taken when creating a zip file. For instance, the `sqlfiles.zip` file in the `testdata` folder
+// Care should be taken when creating a zip zipfile. For instance, the `sqlfiles.zip` zipfile in the `testdata` folder
 // was created on a Mac by selecting the folder in the finder, and then selecting the compress option on the context
-// menu. This creates the zip file with the folder included in the file structure. Therefore all of your paths must
+// menu. This creates the zip zipfile with the folder included in the zipfile structure. Therefore all of your paths must
 // include this folder. See the tests for an example.
 package zipack

--- a/zipFile.go
+++ b/zipFile.go
@@ -1,0 +1,48 @@
+package zipack
+
+import (
+	"io"
+	"io/fs"
+	"os"
+)
+
+func (mgr *Manager) Open(filename string) (fs.File, error) {
+
+	zipfile, err := mgr.readAndStoreFromZip(filename)
+	if err != nil {
+		if verr, ok := err.(*os.PathError); ok {
+			return nil, verr
+		}
+		return nil, err
+	}
+	return zipfile, nil
+}
+
+type zipfile struct {
+	name   string
+	info   fs.FileInfo
+	data   []byte
+	offset int64
+}
+
+// interface check
+var _ fs.File = new(zipfile)
+
+func (z zipfile) Stat() (fs.FileInfo, error) {
+	return z.info, nil
+}
+
+func (z *zipfile) Read(p []byte) (n int, err error) {
+	if z.offset >= int64(len(z.data)) {
+		err = io.EOF
+		return
+	}
+	n = copy(p, z.data[z.offset:])
+	z.offset += int64(n)
+	return
+}
+
+func (z *zipfile) Close() error {
+	z.offset = 0
+	return nil
+}

--- a/zipFile_test.go
+++ b/zipFile_test.go
@@ -1,0 +1,107 @@
+package zipack
+
+import (
+	"bytes"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+type tstFileInfo struct {
+	Msg []byte
+	Dir bool
+}
+
+func (t tstFileInfo) Name() string {
+	return "test"
+}
+
+func (t tstFileInfo) Size() int64 {
+	return int64(len(t.Msg))
+}
+
+func (t tstFileInfo) Mode() fs.FileMode {
+	return 0666
+}
+
+func (t tstFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (t tstFileInfo) IsDir() bool {
+	return t.Dir
+}
+
+func (t tstFileInfo) Sys() interface{} {
+	return nil
+}
+
+func TestZipfile_Read(t *testing.T) {
+	tests := []tstFileInfo{
+		{
+			Msg: []byte("Testing"),
+			Dir: false,
+		},
+	}
+
+	for _, tst := range tests {
+		zf := zipfile{
+			name: tst.Name(),
+			info: tst,
+			data: tst.Msg,
+		}
+		buf := make([]byte, len(tst.Msg))
+		if _, err := zf.Read(buf); err != nil {
+			t.Errorf("cannot read zipfile: %s", err)
+		}
+		if !bytes.Equal(buf, tst.Msg) {
+			t.Errorf("read contents not equal: Actual(%s), Expected(%s)", string(buf), string(tst.Msg))
+		}
+	}
+}
+
+func TestZipfile_httpFS(t *testing.T) {
+	mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
+	mux := http.NewServeMux()
+	mux.Handle("/", http.FileServer(http.FS(mgr)))
+
+	t.Run("SqlFile", func(t *testing.T) {
+		filePath := "/sqlfiles/default/selectDual.sql"
+		req := httptest.NewRequest("GET", filePath, nil)
+		wr := httptest.NewRecorder()
+
+		mux.ServeHTTP(wr, req)
+
+		resp := wr.Result()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("unexpected status code: Actual(%d), Expected(%d)", resp.StatusCode, http.StatusOK)
+		}
+
+		buf, err := os.ReadFile(path.Join("./testdata", filePath))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(buf, wr.Body.Bytes()) {
+			t.Errorf("data not read correctly: Actual(%s), Expected(%s)", wr.Body.String(), string(buf))
+		}
+	})
+
+	t.Run("Check directory", func(t *testing.T) {
+		filePath := "/sqlfiles/"
+		req := httptest.NewRequest("GET", filePath, nil)
+		wr := httptest.NewRecorder()
+
+		mux.ServeHTTP(wr, req)
+
+		resp := wr.Result()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("unexpected status code: Actual(%d), Expected(%d)", resp.StatusCode, http.StatusOK)
+		}
+	})
+}

--- a/zipack_bench_test.go
+++ b/zipack_bench_test.go
@@ -22,8 +22,8 @@ func BenchmarkGetReaderWCache(b *testing.B) {
 			}
 		}
 	}
-	b.Run("small file", test(filepath.Join("sqlfiles","default", "selectDual.sql")))
-	b.Run("larger file", test(filepath.Join("sqlfiles","largerFile.txt")))
+	b.Run("small zipfile", test(filepath.Join("sqlfiles", "default", "selectDual.sql")))
+	b.Run("larger zipfile", test(filepath.Join("sqlfiles", "largerFile.txt")))
 }
 
 func BenchmarkGetFileContentsWCache(b *testing.B) {
@@ -40,8 +40,8 @@ func BenchmarkGetFileContentsWCache(b *testing.B) {
 			}
 		}
 	}
-	b.Run("small file", test(filepath.Join("sqlfiles","default", "selectDual.sql")))
-	b.Run("larger file", test(filepath.Join("sqlfiles","largerFile.txt")))
+	b.Run("small zipfile", test(filepath.Join("sqlfiles", "default", "selectDual.sql")))
+	b.Run("larger zipfile", test(filepath.Join("sqlfiles", "largerFile.txt")))
 }
 func BenchmarkOsOpenFileReadAllNonZipWSimilarCache(b *testing.B) {
 	test := func(fileKey string) func(*testing.B) {
@@ -54,8 +54,8 @@ func BenchmarkOsOpenFileReadAllNonZipWSimilarCache(b *testing.B) {
 			}
 		}
 	}
-	b.Run("small file", test("./testdata/sqlfiles/default/selectDual.sql"))
-	b.Run("larger file", test("./testdata/sqlfiles/largerFile.txt"))
+	b.Run("small zipfile", test("./testdata/sqlfiles/default/selectDual.sql"))
+	b.Run("larger zipfile", test("./testdata/sqlfiles/largerFile.txt"))
 }
 
 func BenchmarkGetReaderWithDeleteCache(b *testing.B) {
@@ -76,8 +76,8 @@ func BenchmarkGetReaderWithDeleteCache(b *testing.B) {
 			}
 		}
 	}
-	b.Run("small file", test(filepath.Join("sqlfiles","default", "selectDual.sql")))
-	b.Run("larger file", test(filepath.Join("sqlfiles","largerFile.txt")))
+	b.Run("small zipfile", test(filepath.Join("sqlfiles", "default", "selectDual.sql")))
+	b.Run("larger zipfile", test(filepath.Join("sqlfiles", "largerFile.txt")))
 }
 
 func BenchmarkGetFileContentsWithDeleteCache(b *testing.B) {
@@ -97,8 +97,8 @@ func BenchmarkGetFileContentsWithDeleteCache(b *testing.B) {
 			}
 		}
 	}
-	b.Run("small file", test(filepath.Join("sqlfiles","default", "selectDual.sql")))
-	b.Run("larger file", test(filepath.Join("sqlfiles","largerFile.txt")))
+	b.Run("small zipfile", test(filepath.Join("sqlfiles", "default", "selectDual.sql")))
+	b.Run("larger zipfile", test(filepath.Join("sqlfiles", "largerFile.txt")))
 
 }
 func BenchmarkOsOpenFileReadAllNonZipNoCache(b *testing.B) {
@@ -117,8 +117,8 @@ func BenchmarkOsOpenFileReadAllNonZipNoCache(b *testing.B) {
 			}
 		}
 	}
-	b.Run("small file", test("./testdata/sqlfiles/default/selectDual.sql"))
-	b.Run("larger file", test("./testdata/sqlfiles/largerFile.txt"))
+	b.Run("small zipfile", test("./testdata/sqlfiles/default/selectDual.sql"))
+	b.Run("larger zipfile", test("./testdata/sqlfiles/largerFile.txt"))
 }
 
 var cache sync.Map

--- a/zipack_test.go
+++ b/zipack_test.go
@@ -14,7 +14,7 @@ func TestGetReader(t *testing.T) {
 	mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
 
 	// Call Function
-	r, err := mgr.GetReader(filepath.Join("sqlfiles","default", "selectDual.sql"))
+	r, err := mgr.GetReader(filepath.Join("sqlfiles", "default", "selectDual.sql"))
 	if err != nil {
 		t.Errorf("Got unexepcted error: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestGetReader(t *testing.T) {
 	}
 
 	t.Run("File does not exist", func(t2 *testing.T) {
-		r2, err2 := mgr.GetReader(filepath.Join("sqlfiles","default", "DOESNOTEXIST.txt"))
+		r2, err2 := mgr.GetReader(filepath.Join("sqlfiles", "default", "DOESNOTEXIST.txt"))
 		if err2 == nil {
 			t2.Errorf("Exepcted error but call succeeded: %v", r2)
 		}
@@ -59,15 +59,23 @@ func TestGetReader(t *testing.T) {
 	})
 
 	t.Run("Use cache", func(t2 *testing.T) {
-		_, err3 := mgr.GetReader(filepath.Join("sqlfiles","default", "selectDual.sql"))
+		_, err3 := mgr.GetReader(filepath.Join("sqlfiles", "default", "selectDual.sql"))
 		if err3 != nil {
 			t2.Errorf("Unexepcted error: %v", err3)
 		}
 	})
 
-	t.Run("Nonzip file", func(t2 *testing.T) {
+	t.Run("Nonzip zipfile", func(t2 *testing.T) {
 		m := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
 		_, err := m.GetReader("doesn't matter")
+		if err == nil {
+			t2.Errorf("Get worked without error")
+		}
+	})
+
+	t.Run("Directory", func(t2 *testing.T) {
+		m := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
+		_, err := m.GetReader("/sqlfiles/")
 		if err == nil {
 			t2.Errorf("Get worked without error")
 		}
@@ -79,7 +87,7 @@ func TestGetFileContents(t *testing.T) {
 	mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
 
 	// Call Function
-	res, err := mgr.GetFileContents(filepath.Join("sqlfiles","default", "selectDual.sql"))
+	res, err := mgr.GetFileContents(filepath.Join("sqlfiles", "default", "selectDual.sql"))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -110,7 +118,7 @@ func TestGetFileContents(t *testing.T) {
 	}
 
 	t.Run("File does not exist", func(t2 *testing.T) {
-		r2, err2 := mgr.GetFileContents(filepath.Join("sqlfiles","default", "DOESNOTEXIST.txt"))
+		r2, err2 := mgr.GetFileContents(filepath.Join("sqlfiles", "default", "DOESNOTEXIST.txt"))
 		if err2 == nil {
 			t2.Errorf("Exepcted error but call succeeded: %v", r2)
 		}
@@ -120,7 +128,7 @@ func TestGetFileContents(t *testing.T) {
 	})
 
 	t.Run("Use cache", func(t2 *testing.T) {
-		_, err3 := mgr.GetFileContents(filepath.Join("sqlfiles","default", "selectDual.sql"))
+		_, err3 := mgr.GetFileContents(filepath.Join("sqlfiles", "default", "selectDual.sql"))
 		if err3 != nil {
 			t2.Errorf("Unexepcted error: %v", err3)
 		}
@@ -131,9 +139,9 @@ func TestPreloadPaths(t *testing.T) {
 	mgr := NewManager(Options{
 		ZipFileName: "./testdata/sqlfiles.zip",
 		PreloadPaths: []string{
-			filepath.Join("sqlfiles","simple", "aa.txt"),
-			filepath.Join("sqlfiles","simple", "bb.txt"),
-			filepath.Join("sqlfiles","simple", "cc.txt"),
+			filepath.Join("sqlfiles", "simple", "aa.txt"),
+			filepath.Join("sqlfiles", "simple", "bb.txt"),
+			filepath.Join("sqlfiles", "simple", "cc.txt"),
 		},
 	})
 
@@ -141,12 +149,12 @@ func TestPreloadPaths(t *testing.T) {
 		Path    string
 		Present bool
 	}{
-		{Path: filepath.Join("sqlfiles","simple", "aa.txt"), Present: true},
-		{Path: filepath.Join("sqlfiles","simple", "bb.txt"), Present: true},
-		{Path: filepath.Join("sqlfiles","simple", "cc.txt"), Present: true},
-		{Path: filepath.Join("sqlfiles","simple", "dd.txt"), Present: false},
-		{Path: filepath.Join("sqlfiles","simple", "ee.txt"), Present: false},
-		{Path: filepath.Join("sqlfiles","simple", "ff.txt"), Present: false},
+		{Path: filepath.Join("sqlfiles", "simple", "aa.txt"), Present: true},
+		{Path: filepath.Join("sqlfiles", "simple", "bb.txt"), Present: true},
+		{Path: filepath.Join("sqlfiles", "simple", "cc.txt"), Present: true},
+		{Path: filepath.Join("sqlfiles", "simple", "dd.txt"), Present: false},
+		{Path: filepath.Join("sqlfiles", "simple", "ee.txt"), Present: false},
+		{Path: filepath.Join("sqlfiles", "simple", "ff.txt"), Present: false},
 	}
 	for _, test := range tests {
 		_, ok := mgr.cache.Load(test.Path)
@@ -157,16 +165,16 @@ func TestPreloadPaths(t *testing.T) {
 }
 
 func TestReadAndStoreFromZip(t *testing.T) {
-	t.Run("zip file exists", func(t *testing.T) {
+	t.Run("zipfile exists", func(t *testing.T) {
 		mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
-		_, err := mgr.readAndStoreFromZip(filepath.Join("sqlfiles","largerFile.txt"))
+		_, err := mgr.readAndStoreFromZip(filepath.Join("sqlfiles", "largerFile.txt"))
 		if err != nil {
 			t.Errorf("Did not expect error: %v", err)
 		}
 	})
-	t.Run("zip file not exists", func(t *testing.T) {
+	t.Run("zipfile not exists", func(t *testing.T) {
 		mgr := NewManager(Options{ZipFileName: "./testdata/fail.zip"})
-		_, err := mgr.readAndStoreFromZip(filepath.Join("sqlfiles","largerFile.txt"))
+		_, err := mgr.readAndStoreFromZip(filepath.Join("sqlfiles", "largerFile.txt"))
 		if err == nil {
 			t.Error("Expected error")
 		}
@@ -174,19 +182,19 @@ func TestReadAndStoreFromZip(t *testing.T) {
 }
 
 /*
- * JAR file in testdata folder has been created by
+ * JAR zipfile in testdata folder has been created by
  *   1. CD into testdata folder
  *   2. Run `jar cf sqlfiles.jar -C sqlfiles .`
  *
- * This is a bit different to the way the zip file was created which includes the sqlfiles folder
+ * This is a bit different to the way the zip zipfile was created which includes the sqlfiles folder
  */
 
-func TestReadJarFile(t *testing.T){
-	// SETUP - with a JAR file instead.
+func TestReadJarFile(t *testing.T) {
+	// SETUP - with a JAR zipfile instead.
 	mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.jar"})
 
-	zipPath:= filepath.Join("default", "selectDual.sql")
-	fixturePath := filepath.Join("testdata", "sqlfiles",zipPath)
+	zipPath := filepath.Join("default", "selectDual.sql")
+	fixturePath := filepath.Join("testdata", "sqlfiles", zipPath)
 
 	// Get File contents
 	res, err := mgr.GetFileContents(zipPath)
@@ -199,14 +207,14 @@ func TestReadJarFile(t *testing.T){
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(res,filedata) {
-		t.Errorf("data note the same: %d",bytes.Compare(res,filedata))
+	if !bytes.Equal(res, filedata) {
+		t.Errorf("data note the same: %d", bytes.Compare(res, filedata))
 	}
 }
 
 func ExampleManager_GetFileContents() {
 	mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
-	fileKey := filepath.Join("sqlfiles","default", "selectDual.sql")
+	fileKey := filepath.Join("sqlfiles", "default", "selectDual.sql")
 	res, err := mgr.GetFileContents(fileKey)
 	if err != nil {
 		panic(fmt.Errorf("Unexpected error: %v", err))


### PR DESCRIPTION
It is now possible to utilise the zipack manager directly in a `http.Fileserver`. It implements the `fs.FS` interface and can be passed to the `http.FS` function:

```go
mgr := NewManager(Options{ZipFileName: "./testdata/sqlfiles.zip"})
mux := http.NewServeMux()
mux.Handle("/", http.FileServer(http.FS(mgr)))
```